### PR TITLE
Refactored to match 2026.1 typings

### DIFF
--- a/components/shys_m5_dial/ha_api.h
+++ b/components/shys_m5_dial/ha_api.h
@@ -17,11 +17,11 @@ namespace esphome
 
                 void updateEntity(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("homeassistant.update_entity"));
+                    resp.service = esphome::StringRef("homeassistant.update_entity");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "update Entity: %s", entity.c_str());
                 }
@@ -30,18 +30,18 @@ namespace esphome
 
                 void turnLightOn(const std::string& entity, int brightness = -1, int colorValue = -1){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("light.turn_on"));
+                    resp.service = esphome::StringRef("light.turn_on");
 
                     int data_count = 1 + (brightness >= 0 ? 1 : 0);
                     resp.data.init(data_count);
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     if(brightness >= 0){
                         auto &kv2 = resp.data.emplace_back();
-                        kv2.set_key(esphome::StringRef("brightness_pct"));
-                        kv2.value = to_string(brightness);
+                        kv2.key = esphome::StringRef("brightness_pct");
+                        kv2.value = esphome::StringRef(to_string(brightness));
                         ESP_LOGD("HA_API", "Turn ON %s with brightness: %i", entity.c_str(), brightness);
                     }
 
@@ -49,11 +49,11 @@ namespace esphome
                         // Verwende data_template mit Home Assistant Template-Syntax
                         resp.data_template.init(1);
                         auto &kv3 = resp.data_template.emplace_back();
-                        kv3.set_key(esphome::StringRef("hs_color"));
+                        kv3.key = esphome::StringRef("hs_color");
                         // Template: {{(hue,saturation)|list}} wird zu echtem Array
                         char colorTemplate[32];
                         snprintf(colorTemplate, sizeof(colorTemplate), "{{(%d,100)|list}}", colorValue);
-                        kv3.value = std::string(colorTemplate);
+                        kv3.value = esphome::StringRef(colorTemplate);
                         ESP_LOGI("HA_API", "Turn ON %s with color template: %s", entity.c_str(), colorTemplate);
                     }
 
@@ -63,19 +63,19 @@ namespace esphome
 
                 void turnLightOnWhite(const std::string& entity, int kelvin = -1){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("light.turn_on"));
+                    resp.service = esphome::StringRef("light.turn_on");
                     
                     int data_count = (kelvin >= 0) ? 2 : 1;
                     resp.data.init(data_count);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     if(kelvin >= 0){
                         auto &kv2 = resp.data.emplace_back();
-                        kv2.set_key(esphome::StringRef("kelvin"));
-                        kv2.value = to_string(kelvin);
+                        kv2.key = esphome::StringRef("kelvin");
+                        kv2.value = esphome::StringRef(to_string(kelvin));
                         ESP_LOGD("HA_API", "Turn ON %s with kelvin: %i", entity.c_str(), kelvin);
                     }
 
@@ -86,22 +86,22 @@ namespace esphome
 
                 void turnLightOff(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("light.turn_off"));
+                    resp.service = esphome::StringRef("light.turn_off");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn OFF Light: %s", entity.c_str());
                 }
 
                 void toggleLight(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("light.toggle"));
+                    resp.service = esphome::StringRef("light.toggle");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "toggle Light: %s", entity.c_str());
                 }
@@ -113,38 +113,38 @@ namespace esphome
 
                 void turnClimateOn(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("climate.turn_on"));
+                    resp.service = esphome::StringRef("climate.turn_on");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn ON Climate: %s", entity.c_str());
                 }
 
                 void turnClimateOff(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("climate.turn_off"));
+                    resp.service = esphome::StringRef("climate.turn_off");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn OFF Climate: %s", entity.c_str());
                 }
 
                 void setClimateTemperature(const std::string& entity, int value){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("climate.set_temperature"));
+                    resp.service = esphome::StringRef("climate.set_temperature");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("temperature"));
-                    kv2.value = to_string(value);
+                    kv2.key = esphome::StringRef("temperature");
+                    kv2.value = esphome::StringRef(to_string(value));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Climate set Temperature: %i on %s", value, entity.c_str());
@@ -152,16 +152,16 @@ namespace esphome
 
                 void setClimateFanMode(const std::string& entity, const std::string& mode){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("climate.set_fan_mode"));
+                    resp.service = esphome::StringRef("climate.set_fan_mode");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("fan_mode"));
-                    kv2.value = mode;
+                    kv2.key = esphome::StringRef("fan_mode");
+                    kv2.value = esphome::StringRef(mode);
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Climate set Fan-Mode: %s on %s", mode.c_str(), entity.c_str());
@@ -171,16 +171,16 @@ namespace esphome
 
                 void setCoverPosition(const std::string& entity, int value){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("cover.set_cover_position"));
+                    resp.service = esphome::StringRef("cover.set_cover_position");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("position"));
-                    kv2.value = to_string(value);
+                    kv2.key = esphome::StringRef("position");
+                    kv2.value = esphome::StringRef(to_string(value));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Cover set Position: %i on %s", value, entity.c_str());
@@ -193,33 +193,33 @@ namespace esphome
 
                 void turnSwitchOn(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("switch.turn_on"));
+                    resp.service = esphome::StringRef("switch.turn_on");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn ON Switch: %s", entity.c_str());
                 }
 
                 void turnSwitchOff(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("switch.turn_off"));
+                    resp.service = esphome::StringRef("switch.turn_off");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn OFF Switch: %s", entity.c_str());
                 }
 
                 void toggleSwitch(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("switch.toggle"));
+                    resp.service = esphome::StringRef("switch.toggle");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "toggle Switch: %s", entity.c_str());
                 }
@@ -231,49 +231,49 @@ namespace esphome
 
                 void turnFanOn(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("fan.turn_on"));
+                    resp.service = esphome::StringRef("fan.turn_on");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn ON Fan: %s", entity.c_str());
                 }
 
                 void turnFanOff(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("fan.turn_off"));
+                    resp.service = esphome::StringRef("fan.turn_off");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "turn OFF Fan: %s", entity.c_str());
                 }
 
                 void toggleFan(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("fan.toggle"));
+                    resp.service = esphome::StringRef("fan.toggle");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "toggle Fan: %s", entity.c_str());
                 }
 
                 void setFanDirection(const std::string& entity, const char* direction){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("fan.set_direction"));
+                    resp.service = esphome::StringRef("fan.set_direction");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("direction"));
-                    kv2.value = direction;
+                    kv2.key = esphome::StringRef("direction");
+                    kv2.value = esphome::StringRef(direction);
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Fan set Direction: %s on %s", direction, entity.c_str());
@@ -281,16 +281,16 @@ namespace esphome
 
                 void setFanSpeed(const std::string& entity, int value){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("fan.set_percentage"));
+                    resp.service = esphome::StringRef("fan.set_percentage");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("percentage"));
-                    kv2.value = to_string(value);
+                    kv2.key = esphome::StringRef("percentage");
+                    kv2.value = esphome::StringRef(to_string(value));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Fan set Speed: %i on %s", value, entity.c_str());
@@ -304,16 +304,16 @@ namespace esphome
 
                 void setMediaPlayerVolume(const std::string& entity, int value){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("media_player.volume_set"));
+                    resp.service = esphome::StringRef("media_player.volume_set");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("volume_level"));
-                    kv2.value = to_string((float)value/100);
+                    kv2.key = esphome::StringRef("volume_level");
+                    kv2.value = esphome::StringRef(to_string((float)value/100));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer set Volume: %i on %s", value, entity.c_str());
@@ -321,64 +321,64 @@ namespace esphome
 
                 void stopMediaPlayer(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("media_player.media_stop"));
+                    resp.service = esphome::StringRef("media_player.media_stop");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer Stop: %s", entity.c_str());
                 }
 
                 void setNextTrackOnMediaPlayer(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("media_player.media_next_track"));
+                    resp.service = esphome::StringRef("media_player.media_next_track");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer next Track: %s", entity.c_str());
                 }
 
                 void setPreviousTrackOnMediaPlayer(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("media_player.media_previous_track"));
+                    resp.service = esphome::StringRef("media_player.media_previous_track");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer previous Track: %s", entity.c_str());
                 }
 
                 void playPauseMediaPlayer(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("media_player.media_play_pause"));
+                    resp.service = esphome::StringRef("media_player.media_play_pause");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer play/pause: %s", entity.c_str());
                 }
 
                 void playMediaOnMediaPlayer(const std::string& entity, const std::string& media_content_id, const std::string& media_content_type){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("media_player.play_media"));
+                    resp.service = esphome::StringRef("media_player.play_media");
                     resp.data.init(3);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("media_content_id"));
-                    kv2.value = media_content_id;
+                    kv2.key = esphome::StringRef("media_content_id");
+                    kv2.value = esphome::StringRef(media_content_id);
 
                     auto &kv3 = resp.data.emplace_back();
-                    kv3.set_key(esphome::StringRef("media_content_type"));
-                    kv3.value = media_content_type;
+                    kv3.key = esphome::StringRef("media_content_type");
+                    kv3.value = esphome::StringRef(media_content_type);
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer play_media: %s on %s", media_content_id.c_str(), entity.c_str());
@@ -386,11 +386,11 @@ namespace esphome
 
                 void refreshMediaPlayer(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("homeassistant.update_entity"));
+                    resp.service = esphome::StringRef("homeassistant.update_entity");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "MediaPlayer refresh: %s", entity.c_str());
                 }
@@ -403,33 +403,33 @@ namespace esphome
 
                 void openLock(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("lock.open"));
+                    resp.service = esphome::StringRef("lock.open");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Lock open: %s", entity.c_str());
                 }
 
                 void lockLock(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("lock.lock"));
+                    resp.service = esphome::StringRef("lock.lock");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Lock lock: %s", entity.c_str());
                 }
 
                 void unlockLock(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("lock.unlock"));
+                    resp.service = esphome::StringRef("lock.unlock");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Lock unlock: %s", entity.c_str());
                 }
@@ -443,16 +443,16 @@ namespace esphome
                                          "input_number.set_value" : "number.set_value";
                     
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef(service));
+                    resp.service = esphome::StringRef(service);
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("value"));
-                    kv2.value = to_string(value);
+                    kv2.key = esphome::StringRef("value");
+                    kv2.value = esphome::StringRef(to_string(value));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Number set Value: %i on %s", value, entity.c_str());
@@ -467,12 +467,12 @@ namespace esphome
                 // Timer start without duration (uses timer's default duration)
                 void timerStart(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("timer.start"));
+                    resp.service = esphome::StringRef("timer.start");
                     resp.data.init(1);
                     
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Timer start (default duration) on %s", entity.c_str());
@@ -481,16 +481,16 @@ namespace esphome
                 // Timer start with specific duration
                 void timerStart(const std::string& entity, int duration){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("timer.start"));
+                    resp.service = esphome::StringRef("timer.start");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("duration"));
-                    kv2.value = to_string(duration);
+                    kv2.key = esphome::StringRef("duration");
+                    kv2.value = esphome::StringRef(to_string(duration));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Timer start: %i on %s", duration, entity.c_str());
@@ -498,49 +498,49 @@ namespace esphome
 
                 void timerPause(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("timer.pause"));
+                    resp.service = esphome::StringRef("timer.pause");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Timer pause: %s", entity.c_str());
                 }
 
                 void timerCancle(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("timer.cancle"));
+                    resp.service = esphome::StringRef("timer.cancle");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Timer cancle: %s", entity.c_str());
                 }
 
                 void timerFinish(const std::string& entity){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("timer.finish"));
+                    resp.service = esphome::StringRef("timer.finish");
                     resp.data.init(1);
                     auto &kv = resp.data.emplace_back();
-                    kv.set_key(esphome::StringRef("entity_id"));
-                    kv.value = entity;
+                    kv.key = esphome::StringRef("entity_id");
+                    kv.value = esphome::StringRef(entity);
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Timer finish: %s", entity.c_str());
                 }
 
                 void timerChange(const std::string& entity, int duration){
                     esphome::api::HomeassistantActionRequest resp;
-                    resp.set_service(esphome::StringRef("timer.change"));
+                    resp.service = esphome::StringRef("timer.change");
                     resp.data.init(2);
                     
                     auto &kv1 = resp.data.emplace_back();
-                    kv1.set_key(esphome::StringRef("entity_id"));
-                    kv1.value = entity;
+                    kv1.key = esphome::StringRef("entity_id");
+                    kv1.value = esphome::StringRef(entity);
 
                     auto &kv2 = resp.data.emplace_back();
-                    kv2.set_key(esphome::StringRef("duration"));
-                    kv2.value = to_string(duration);
+                    kv2.key = esphome::StringRef("duration");
+                    kv2.value = esphome::StringRef(to_string(duration));
 
                     api::global_api_server->send_homeassistant_action(resp);
                     ESP_LOGD("HA_API", "Timer change: %i on %s", duration, entity.c_str());

--- a/components/shys_m5_dial/ha_device_mode_climate_fan.h
+++ b/components/shys_m5_dial/ha_device_mode_climate_fan.h
@@ -85,12 +85,12 @@ namespace esphome
                     if (modeConfig["fan_mode"].is<JsonObject>() && !manualModes) {
                         api::global_api_server->subscribe_home_assistant_state(
                                     this->device.getEntityId().c_str(),
-                                    optional<std::string>("fan_modes"), 
-                                    [this](const std::string &state) {
+                                    optional<std::string>(std::string("fan_modes")), 
+                                    [this](const esphome::StringRef state) {
 
                             ESP_LOGI("HA_API", "Got Climate Fan-Mode %s for %s", state.c_str(), this->device.getEntityId().c_str());
 
-                            std::string str = state;
+                            std::string str = state.str();
                             str.erase(std::remove(str.begin(), str.end(), '['), str.end());
                             str.erase(std::remove(str.begin(), str.end(), ']'), str.end());
                             str.erase(std::remove(str.begin(), str.end(), '\''), str.end());

--- a/components/shys_m5_dial/ha_device_mode_climate_temperature.h
+++ b/components/shys_m5_dial/ha_device_mode_climate_temperature.h
@@ -36,9 +36,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
 
                         if(this->isValueModified()){
                             return;
@@ -49,15 +49,15 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("temperature"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("temperature")), 
+                                [this](const esphome::StringRef state) {
 
                         if(this->isValueModified()){
                             return;
                         }
 
-                        auto val = parse_number<float>(state);
+                        auto val = parse_number<float>(state.str());
 
                         if (!val.has_value()) {
                             this->setReceivedValue(0);

--- a/components/shys_m5_dial/ha_device_mode_cover_position.h
+++ b/components/shys_m5_dial/ha_device_mode_cover_position.h
@@ -20,12 +20,12 @@ namespace esphome
                 void registerHAListener() {
                     api::global_api_server->subscribe_home_assistant_state(
                                 this->device.getEntityId().c_str(),
-                                optional<std::string>("current_position"), 
-                                [this](const std::string &state) {
+                                optional<std::string>(std::string("current_position")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
-                        auto val = parse_number<int>(state);
+                        auto val = parse_number<int>(state.str());
                         if (!val.has_value()) {
                             this->setReceivedValue(0);
                             ESP_LOGD("HA_API", "No Position value in %s for %s", state.c_str(), this->device.getEntityId().c_str());

--- a/components/shys_m5_dial/ha_device_mode_fan_speed.h
+++ b/components/shys_m5_dial/ha_device_mode_fan_speed.h
@@ -153,9 +153,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
@@ -165,13 +165,13 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>("percentage"), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
-                        auto val = parse_number<int>(state);
+                        auto val = parse_number<int>(state.str());
                         if (!val.has_value()) {
                             this->setReceivedValue(0);
                             ESP_LOGD("HA_API", "No Percentage value in %s for %s", state.c_str(), this->device.getEntityId().c_str());
@@ -183,9 +183,9 @@ namespace esphome
 
                     if(this->changeableDirection){
                         api::global_api_server->subscribe_home_assistant_state(
-                                    this->device.getEntityId().c_str(),
+                                    this->device.getEntityId(),
                                     optional<std::string>("direction"), 
-                                    [this](const std::string &state) {
+                                    [this](const esphome::StringRef state) {
                             if(this->isValueModified()){
                                 return;
                             }

--- a/components/shys_m5_dial/ha_device_mode_light_brightness.h
+++ b/components/shys_m5_dial/ha_device_mode_light_brightness.h
@@ -23,13 +23,13 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("brightness"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("brightness")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
-                        auto val = parse_number<int>(state);
+                        auto val = parse_number<int>(state.str());
                         if (!val.has_value()) {
                             this->setReceivedValue(0);
                             ESP_LOGD("HA_API", "No Brightness value in %s for %s", state.c_str(), this->device.getEntityId().c_str());

--- a/components/shys_m5_dial/ha_device_mode_light_color.h
+++ b/components/shys_m5_dial/ha_device_mode_light_color.h
@@ -152,19 +152,19 @@ namespace esphome
                 void registerHAListener() override {
                     std::string attrName = "hs_color";
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(attrName), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                                 
                         if(this->isValueModified()){
                             return;
                         }
 
                         std::string colorString = "";          
-                        std::string::size_type pos = state.find(',');
+                        std::string::size_type pos = state.str().find(',');
                         
                         if (pos != std::string::npos) {
-                            colorString = state.substr(1, pos-1);
+                            colorString = state.str().substr(1, pos-1);
                         }
                         ESP_LOGD("HA_API", "HS_Color value %s for %s", colorString.c_str(), this->device.getEntityId().c_str());
 

--- a/components/shys_m5_dial/ha_device_mode_light_on_off.h
+++ b/components/shys_m5_dial/ha_device_mode_light_on_off.h
@@ -55,9 +55,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                                     
                         if(this->isValueModified()){
                             return;

--- a/components/shys_m5_dial/ha_device_mode_light_tunable_white.h
+++ b/components/shys_m5_dial/ha_device_mode_light_tunable_white.h
@@ -192,9 +192,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("color_temp_kelvin"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("color_temp_kelvin")), 
+                                [this](const esphome::StringRef state) {
 
                         if(this->isValueModified()){
                             return;

--- a/components/shys_m5_dial/ha_device_mode_lock.h
+++ b/components/shys_m5_dial/ha_device_mode_lock.h
@@ -126,9 +126,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
 
                         if(this->isValueModified()){
                             return;

--- a/components/shys_m5_dial/ha_device_mode_mediaplayer_play.h
+++ b/components/shys_m5_dial/ha_device_mode_mediaplayer_play.h
@@ -140,9 +140,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("volume_level"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("volume_level")), 
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;
@@ -164,9 +164,9 @@ namespace esphome
 
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;
@@ -179,9 +179,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("media_title"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("media_title")), 
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;
@@ -194,9 +194,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("media_artist"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("media_artist")), 
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;
@@ -209,9 +209,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("media_album_name"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("media_album_name")), 
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;
@@ -224,9 +224,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("media_duration"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("media_duration")), 
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;
@@ -243,9 +243,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("media_position"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("media_position")), 
+                                [this](const esphome::StringRef state) {
                         
                         if(this->isValueModified()){
                             return;

--- a/components/shys_m5_dial/ha_device_mode_number_value.h
+++ b/components/shys_m5_dial/ha_device_mode_number_value.h
@@ -20,9 +20,9 @@ namespace esphome
 
                 void registerHAListener() {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
@@ -37,9 +37,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("min"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("min")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
@@ -54,9 +54,9 @@ namespace esphome
                     });
                     
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("max"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("max")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }

--- a/components/shys_m5_dial/ha_device_mode_switch_on_off.h
+++ b/components/shys_m5_dial/ha_device_mode_switch_on_off.h
@@ -55,9 +55,9 @@ namespace esphome
 
                 void registerHAListener() override {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                                     
                         if(this->isValueModified()){
                             return;

--- a/components/shys_m5_dial/ha_device_mode_timer_handling.h
+++ b/components/shys_m5_dial/ha_device_mode_timer_handling.h
@@ -145,9 +145,9 @@ namespace esphome
 
                 void registerHAListener() {
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
+                                this->device.getEntityId(),
                                 optional<std::string>(), 
-                                [this](const std::string &state) {
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
@@ -168,9 +168,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("duration"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("duration")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
@@ -182,9 +182,9 @@ namespace esphome
                     });
 
                     api::global_api_server->subscribe_home_assistant_state(
-                                this->device.getEntityId().c_str(),
-                                optional<std::string>("remaining"), 
-                                [this](const std::string &state) {
+                                this->device.getEntityId(),
+                                optional<std::string>(std::string("remaining")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }
@@ -197,8 +197,8 @@ namespace esphome
 
                     api::global_api_server->subscribe_home_assistant_state(
                                 this->device.getEntityId().c_str(),
-                                optional<std::string>("finishes_at"), 
-                                [this](const std::string &state) {
+                                optional<std::string>(std::string("finishes_at")), 
+                                [this](const esphome::StringRef state) {
                         if(this->isValueModified()){
                             return;
                         }

--- a/shys-m5-dial.yaml
+++ b/shys-m5-dial.yaml
@@ -25,6 +25,7 @@ external_components:
       url: https://github.com/SmartHome-yourself/m5-dial-for-esphome/
       ref: main
     components: [shys_m5_dial]
+    refresh: 1s
 
 dashboard_import:
   package_import_url: github://SmartHome-yourself/m5-dial-for-esphome/shys-m5-dial.yaml@main


### PR DESCRIPTION
In my instance running on version 2026.1.3, the component doesn't compile anymore. Looks like 2026.1 changes a bit how the protobuf objects are generated and also declaration of the `` function. 

I haven't found any information about this on the Internet, but looks like the `set_service`, `set_key` methods indeed don't exist anymore (see [reference](https://api-docs.esphome.io/classesphome_1_1api_1_1_homeassistant_action_request))

Here are snapshots from logs with the current version:

```
In file included from src/esphome.h:46:
src/esphome/components/shys_m5_dial/ha_api.h: In member function 'void esphome::shys_m5_dial::HaApi::updateEntity(const std::string&)':
src/esphome/components/shys_m5_dial/ha_api.h:20:26: error: 'class esphome::api::HomeassistantActionRequest' has no member named 'set_service'; did you mean 'service'?
   20 |                     resp.set_service(esphome::StringRef("homeassistant.update_entity"));
      |                          ^~~~~~~~~~~
      |                          service
src/esphome/components/shys_m5_dial/ha_api.h:23:24: error: 'class esphome::api::HomeassistantServiceMap' has no member named 'set_key'
   23 |                     kv.set_key(esphome::StringRef("entity_id"));
      |                        ^~~~~~~
src/esphome/components/shys_m5_dial/ha_api.h:24:32: error: no match for 'operator=' (operand types are 'esphome::StringRef' and 'const std::string' {aka 'const std::__cxx11::basic_string<char>'})
   24 |                     kv.value = entity;
      |                                ^~~~~~
In file included from src/esphome/core/application.h:17,
                 from src/esphome/components/api/api_frame_helper.h:13,
                 from src/esphome/components/api/api_connection.h:5,
                 from src/esphome.h:3:
src/esphome/core/string_ref.h:26:7: note: candidate: 'constexpr esphome::StringRef& esphome::StringRef::operator=(const esphome::StringRef&)'
   26 | class StringRef {
      |       ^~~~~~~~~
src/esphome/core/string_ref.h:26:7: note:   no known conversion for argument 1 from 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to 'const esphome::StringRef&'
src/esphome/core/string_ref.h:26:7: note: candidate: 'constexpr esphome::StringRef& esphome::StringRef::operator=(esphome::StringRef&&)'
src/esphome/core/string_ref.h:26:7: note:   no known conversion for argument 1 from 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to 'esphome::StringRef&&'
src/esphome/components/shys_m5_dial/ha_api.h: In member function 'void esphome::shys_m5_dial::HaApi::turnLightOn(const std::string&, int, int)':
src/esphome/components/shys_m5_dial/ha_api.h:33:26: error: 'class esphome::api::HomeassistantActionRequest' has no member named 'set_service'; did you mean 'service'?
   33 |                     resp.set_service(esphome::StringRef("light.turn_on"));
      |                          ^~~~~~~~~~~
      |                          service
src/esphome/components/shys_m5_dial/ha_api.h:38:25: error: 'class esphome::api::HomeassistantServiceMap' has no member named 'set_key'
   38 |                     kv1.set_key(esphome::StringRef("entity_id"));
      |                         ^~~~~~~
src/esphome/components/shys_m5_dial/ha_api.h:39:33: error: no match for 'operator=' (operand types are 'esphome::StringRef' and 'const std::string' {aka 'const std::__cxx11::basic_string<char>'})
   39 |                     kv1.value = entity;
      |                                 ^~~~~~
```

```
src/esphome/components/shys_m5_dial/ha_device_mode_fan_speed.h: In member function 'virtual void esphome::shys_m5_dial::HaDeviceModeFanSpeed::registerHAListener()':
src/esphome/components/shys_m5_dial/ha_device_mode_fan_speed.h:155:75: error: call of overloaded 'subscribe_home_assistant_state(const char*, esphome::optional<std::__cxx11::basic_string<char> >, esphome::shys_m5_dial::HaDeviceModeFanSpeed::registerHAListener()::<lambda(const std::string&)>)' is ambiguous
  155 |                     api::global_api_server->subscribe_home_assistant_state(
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  156 |                                 this->device.getEntityId().c_str(),
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        
  157 |                                 optional<std::string>(),
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~                   
  158 |                                 [this](const std::string &state) {
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         
  159 |                         if(this->isValueModified()){
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~                       
  160 |                             return;
      |                             ~~~~~~~                                        
  161 |                         }
      |                         ~                                                  
  162 | 
      |                                                                            
  163 |                         this->setState(state);
      |                         ~~~~~~~~~~~~~~~~~~~~~~                             
  164 |                         ESP_LOGI("HA_API", "Got State %s for %s", state.c_str(), this->device.getEntityId().c_str());
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  165 |                     });
      |                     ~~                                                     
```

I don't have the opportunity to test the change with all entity types and all modes, but it compiles now, and the light entities seem to work.